### PR TITLE
fix: type inference of value in register function

### DIFF
--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -7,7 +7,6 @@ import {
   FieldValues,
   RegisterOptions,
   UseForm,
-  ValidationRule,
 } from "../types";
 import { getNestedValue } from "../helpers/getNestedValue";
 import { setNestedValue } from "../helpers/setNestedValue";
@@ -24,10 +23,9 @@ export function useForm<T extends FieldValues>(): UseForm<T> {
   const [errors, setErrors] = useState<FieldErrors<T>>({});
 
   // Store validation rules for each field
-  const fieldsRef = useRef<Record<FieldPath<T>, ValidationRule<T>>>(
-    {} as Record<FieldPath<T>, ValidationRule<T>>
-  );
-
+  const fieldsRef = useRef<{
+    [K in FieldPath<T>]?: RegisterOptions<T, K>;
+  }>({});
   /**
    * Registers a field with the form.
    * @param {keyof T} name - The name of the field to register.
@@ -35,7 +33,7 @@ export function useForm<T extends FieldValues>(): UseForm<T> {
    * @returns {Object} An object with field properties for React.
    */
   const register = useCallback(
-    <P extends FieldPath<T>>(name: P, options: RegisterOptions<T> = {}) => {
+    <P extends FieldPath<T>>(name: P, options: RegisterOptions<T, P> = {}) => {
       // Store validation rules for the field
       fieldsRef.current[name] = options;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,20 +42,23 @@ export type FieldErrors<T extends FieldValues> = {
   [K in FieldPath<T>]?: string;
 };
 
-export type ValidationRule<T> = {
+export type ValidationRule<T extends FieldValues, P extends FieldPath<T>> = {
   required?: boolean;
   pattern?: RegExp;
-  validate?: (value: FieldPathValue<T, FieldPath<T>>) => boolean | string;
+  validate?: (value: FieldPathValue<T, P>) => boolean | string;
 };
 
-export type RegisterOptions<T extends FieldValues> = ValidationRule<T>;
+export type RegisterOptions<
+  T extends FieldValues,
+  P extends FieldPath<T>,
+> = ValidationRule<T, P>;
 
 export interface UseForm<T extends FieldValues> {
   register: <P extends FieldPath<T>>(
     name: P,
-    options?: RegisterOptions<T>
+    options?: RegisterOptions<T, P>
   ) => {
-    name: keyof T;
+    name: P;
     onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
     onBlur: () => void;
     ref: (element: HTMLInputElement | null) => void;

--- a/src/validators/validateField.ts
+++ b/src/validators/validateField.ts
@@ -8,7 +8,7 @@ import { isString } from "../types/predicate";
 
 export const validateField = <T extends FieldValues, P extends FieldPath<T>>(
   value: FieldPathValue<T, P>,
-  rules: ValidationRule<T> | undefined
+  rules: ValidationRule<T, P> | undefined
 ) => {
   if (!rules) return "";
 
@@ -24,9 +24,7 @@ export const validateField = <T extends FieldValues, P extends FieldPath<T>>(
 
   // Check custom validation rule
   if (rules.validate) {
-    const validationResult = rules.validate(
-      value as FieldPathValue<T, FieldPath<T>>
-    );
+    const validationResult = rules.validate(value);
     if (isString(validationResult)) {
       return validationResult;
     } else if (!validationResult) {


### PR DESCRIPTION
# Fix type inference of value in register function

## Description
This PR addresses an issue with type inference in the `register` function of our form handling system. The changes improve type safety and ensure better compatibility with complex nested form structures.

## Impact
These changes enhance the developer experience by providing more accurate type checking support when working with form fields, especially in complex nested structures.

## Additional Notes
This update maintains backwards compatibility with existing form implementations while improving type safety for future development.
