### PR TITLE
fix: resolve declaration files generated using another command in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,13 @@
     "/dist"
   ],
   "scripts": {
-    "build": "vite build && npm run types",
+    "build": "vite build",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write 'src/**/*.{ts,tsx}'",
     "preview": "vite preview",
     "prepare": "husky",
-    "test": "jest",
-    "types": "tsc --project tsconfig.app.json --emitDeclarationOnly --outDir dist/types"
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -55,7 +54,8 @@
     "vite-plugin-dts": "^4.2.1"
   },
   "peerDependencies": {
-    "react": "^18.3.1"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "husky": {
     "hooks": {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,13 +5,14 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "outDir": "dist/types",
 
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "declaration": true,
-    "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
+    "declarationDir": "dist/types",
     "isolatedModules": true,
     "moduleDetection": "force",
     "jsx": "react-jsx",
@@ -22,5 +23,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src/**/*"],
+  "exclude": ["dist", "**/__tests__/**/*", "**/examples/**/*"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -9,7 +9,7 @@
     "moduleResolution": "bundler",
     "declaration": true,
     "emitDeclarationOnly": true,
-    "declarationDir": "./dist/types",
+    "declarationDir": "/dist/types",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,8 +10,11 @@ export default defineConfig({
     react(),
     dts({
       include: ["src"],
-      rollupTypes: true,
       outDir: "dist/types",
+      insertTypesEntry: true,
+      staticImport: true,
+      exclude: ["**/__tests__/**/*", "**/examples/**/*"],
+      tsconfigPath: "./tsconfig.app.json",
     }),
   ],
   build: {


### PR DESCRIPTION
This PR resolves the type declaration issue during build and eliminates the need to use separate commands to generate types.  